### PR TITLE
Create a custom jekyll deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Jekyll Deploy
+
+on:
+  push:
+    branches:
+    - master
+  # redeploy once a day to update unpublished pages
+  schedule:
+  - cron: "0 2 * * *"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build and deploy to GitHub Pages
+      uses: EdricChan03/action-build-deploy-ghpages@v2.2.1
+      with:
+        GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}


### PR DESCRIPTION
To take full control of the jekyll processing, we need to build the results on our own pipeline.