### PR TITLE
Add Kerminator to md script

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,14 @@
+# Blog Tools
+Some scripts to make the [IAC weekly status update blog](https://puppetlabs.github.io/iac/) a bit easier to write
+## Kerminator to Markdown
+This script will take the output of the Kerminator command `!modules released` and convert it to a bullet list in markdown with:
+- The module name (hyperlinked to the module on Forge)
+- The version released
+It will skip over unsupported modules
+## Usage Instructions
+- Run `!modules released` and save the output to a file
+- Run `./kerminator_to_blog_md.sh /path/to/kerminator.out`
+- Paste output in to blog post
+- Post blog!
+### TODO
+- Link to specific CHANGELOG section for version we're listing whenever the URI format is more consistent (e.g. https://forge.puppet.com/puppetlabs/accounts/changelog#v610-2020-01-24)

--- a/bin/kerminator_to_blog_md.sh
+++ b/bin/kerminator_to_blog_md.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+FORGE_BASE_URI="https://forge.puppet.com"
+CHANGELOG_URI="changelog#"
+SUPPORTED_TAG="[supported]"
+
+print_usage() {
+	echo -e "\nUSAGE:\n"
+	echo "Run kerminator in Slack to get the last 14 days of released modules: !modules released 14."
+	echo "Save the output of kerminator to a file."
+	echo "Run this script with the first arg pointing to the file above."
+	echo -e "\n./kerminator_to_blog_md.sh /path/to/kerminator_output.txt\n"
+}
+
+if [ -z "$1" ] || [ `test -f "$1"` ]; then
+	print_usage
+	exit 1
+fi
+
+output=""
+skippedModules=0
+
+while read line; do
+	supported=$(echo -ne $line | cut -d ' ' -f 7)
+	if [[ "$supported" == "$SUPPORTED_TAG" ]]; then
+		moduleName=$(echo -ne $line | cut -d ' ' -f 1 | sed 's/-/\//')
+		version=$(echo -ne "v"; echo -ne $line | cut -d ' ' -f 3)
+		output="$output\n- [$moduleName]($FORGE_BASE_URI/$moduleName) ($version)"
+	else
+		skippedModules=$(($skippedModules + 1))	
+	fi
+done < "$1"
+
+echo -e $output | sort
+echo ""
+echo "Skipped unsupported modules: $skippedModules"
+


### PR DESCRIPTION
A script to convert Kerminator's `!modules released` output to markdown for weekly IAC status update blog posts.