### PR TITLE
Fix URL

### DIFF
--- a/_posts/2020-03-20-status-update.md
+++ b/_posts/2020-03-20-status-update.md
@@ -34,7 +34,7 @@ So far, everyone is well equipped to work remotely to their best.
 Over the last week we have released:
 
 - [puppetlabs/postgresql](https://forge.puppet.com/puppetlabs/postgresql) (v6.4.0)
-- [puppetlabs/rook](https://forge.puppet.com/puppetlabs/postgresql) (v0.4.0)
+- [puppetlabs/rook](https://forge.puppet.com/puppetlabs/rook) (v0.4.0)
 
 ## Facter 4 Testing
 


### PR DESCRIPTION
The link to puppetlabs/rook was pointing to the forge page or puppetlabs/postgresql