### PR TITLE
Fix links to rubygems for tools

### DIFF
--- a/_tools/facterdb.md
+++ b/_tools/facterdb.md
@@ -6,7 +6,7 @@ description: "A Database of OS facts provided by Facter."
 appveyor: false
 codecov_token: false
 dependabot: true
-gem: true
+gem: 'facterdb'
 puppet_module: false
 travis_com: false
 travis_org: true

--- a/_tools/metadata-json-lint.md
+++ b/_tools/metadata-json-lint.md
@@ -6,7 +6,7 @@ description: "Tool to check the validity of Puppet metadata.json files."
 appveyor: true
 codecov_token: true
 dependabot: true
-gem: true
+gem: 'metadata-json-lint'
 puppet_module: false
 travis_com: false
 travis_org: true

--- a/_tools/pdk.md
+++ b/_tools/pdk.md
@@ -6,7 +6,7 @@ description: "Command line tool for generating and testing modules."
 appveyor: true
 codecov_token: ef8ebfa9632b46799eb523869ffa6cd5
 dependabot: false
-gem: true
+gem: 'pdk'
 puppet_module: false
 travis_com: false
 travis_org: true

--- a/_tools/puppet-lint.md
+++ b/_tools/puppet-lint.md
@@ -6,7 +6,7 @@ description: "Check that your Puppet manifests conform to the style guide."
 appveyor: true
 codecov_token: false
 dependabot: false
-gem: true
+gem: 'puppet-lint'
 puppet_module: false
 travis_com: false
 travis_org: true

--- a/_tools/puppet-modulebuilder.md
+++ b/_tools/puppet-modulebuilder.md
@@ -6,7 +6,7 @@ description: "The canonical gem to build puppet modules."
 appveyor: true
 codecov_token: ef8ebfa9632b46799eb523869ffa6cd5
 dependabot: true
-gem: true
+gem: 'puppet-modulebuilder'
 puppet_module: false
 travis_com: false
 travis_org: true

--- a/_tools/puppet-syntax.md
+++ b/_tools/puppet-syntax.md
@@ -6,7 +6,7 @@ description: "Syntax checks for Puppet manifests and templates."
 appveyor: false
 codecov_token: false
 dependabot: false
-gem: true
+gem: puppet-syntax
 puppet_module: false
 travis_com: false
 travis_org: true

--- a/_tools/puppetlabs_spec_helper.md
+++ b/_tools/puppetlabs_spec_helper.md
@@ -6,7 +6,7 @@ description: "A set of shared spec helpers specific to Puppetlabs projects."
 appveyor: true
 codecov_token: false
 dependabot: false
-gem: true
+gem: 'puppetlabs_spec_helper'
 puppet_module: false
 travis_com: false
 travis_org: true

--- a/_tools/rspec-puppet-facts.md
+++ b/_tools/rspec-puppet-facts.md
@@ -6,7 +6,7 @@ description: "Simplify your unit tests by looping on every supported Operating S
 appveyor: false
 codecov_token: false
 dependabot: true
-gem: true
+gem: 'rspec-puppet-facts'
 puppet_module: false
 travis_com: false
 travis_org: true

--- a/_tools/rspec-puppet.md
+++ b/_tools/rspec-puppet.md
@@ -6,7 +6,7 @@ description: "RSpec tests for your Puppet manifests."
 appveyor: true
 codecov_token: false
 dependabot: false
-gem: true
+gem: 'rspec-puppet'
 puppet_module: false
 travis_com: false
 travis_org: true


### PR DESCRIPTION
`gem:` needs to list gem name to create correct link