### PR TITLE
update community_management repo url to puppetlabs namespace

### DIFF
--- a/_tools/community_reports.md
+++ b/_tools/community_reports.md
@@ -1,7 +1,7 @@
 ---
 layout: tool
 title: Community reports
-github: underscorgan/community_management
+github: puppetlabs/community_management
 description: "This set of scripts collates daily reports on our responsibilities as the stewards of supported modules."
 appveyor: false
 codecov_token: false


### PR DESCRIPTION
We're now maintaining a heavily modified version of the original scripts