### PR TITLE
Fix categories on network modules

### DIFF
--- a/_modules/cisco_ios.md
+++ b/_modules/cisco_ios.md
@@ -9,5 +9,5 @@ puppet_module: puppetlabs/cisco_ios
 travis_com: false
 travis_org: true
 workflow: false
-category: Network
+category: Networking
 ---

--- a/_modules/device_manager.md
+++ b/_modules/device_manager.md
@@ -9,5 +9,5 @@ puppet_module: puppetlabs/device_manager
 travis_com: false
 travis_org: true
 workflow: false
-category: Network
+category: Networking
 ---

--- a/_modules/puppetlabs-panos.md
+++ b/_modules/puppetlabs-panos.md
@@ -9,5 +9,5 @@ puppet_module: puppetlabs/panos
 travis_com: false
 travis_org: true
 workflow: false
-category: Network
+category: Networking
 ---


### PR DESCRIPTION
The [modules page](https://puppetlabs.github.io/iac/modules/) doesn't list our network modules. This is because the category names were not lining up. This fixes that.