### PR TITLE
(bug) (blog) Fixing formatting of Week 29 blog update

### DIFF
--- a/_lifeofinternatpuppet/post_29.md
+++ b/_lifeofinternatpuppet/post_29.md
@@ -34,6 +34,7 @@ The key learnings from doing these releases were:-
    - [puppetlabs-puppet_conf](https://github.com/puppetlabs/puppetlabs-puppet_conf/pull/142)
    - [puppetlabs-ibm_installation_manager](https://github.com/puppetlabs/puppetlabs-ibm_installation_manager/pull/180)
 
+
 - When raising PRs for the pending blog posts, I noticed that duplicated commits were getting pushed. I learnt another new thing, which was that always fetch and rebase from the main branch, what I was doing before was fetching and rebasing from the checkout branch instead of main branch. Thanks for the tips Paula!
 
 - I reviewed and merged the following PRs for David Swan and Adrian


### PR DESCRIPTION
- There was no spacing between bullet point 5 and 6. Check the link here before merging this PR :- https://puppetlabs.github.io/iac/lifeofinternatpuppet/post_29.html 
- There should also be spaces between bullet points 1 and 2, and that's not rendered correctly too. 
-  I also tried to run it with jekyll build and serve but no spacing was seen between bullet points 1 and 2 as well as 5 and 6
- Check this merged PR for more information :- https://github.com/puppetlabs/iac/pull/218 