### PR TITLE
Add placeholder for guidelines

### DIFF
--- a/_docs/guidelines.md
+++ b/_docs/guidelines.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Module development guidelines
+author: binford2k
+categories:
+  - team
+  - basics
+tags:
+  - git
+  - github
+  - PRs
+  - pull requests
+  - code review
+---
+
+This is a placeholder page for the IAC development standards. Some source material we can use if we want.
+
+* [CONTRIBUTING.md](https://github.com/puppetlabs/puppetlabs-ntp/pull/617)
+* [Best practices module design](https://github.com/puppetlabs/best-practices/blob/master/puppet-module-design.md)
+    * This repo is currently un-owned and may be archived soon. The SA team will own much of the best practices, but this, and other module design guides should be owned by IAC.
+* [Puppet Style Guide](https://puppet.com/docs/puppet/latest/style_guide.html)
+* [OSPA best practices section](https://ospassist.puppet.com/hc/en-us/sections/360007421113-Best-practices)
+* [Beginner's guide to modules](https://puppet.com/docs/puppet/latest/bgtm.html)


### PR DESCRIPTION
This is mostly to "reserve" a URL to link to in the Trusted Contributor
Agreement as it's being drafted. If we don't have better suggestions,
I'd like to put our guidelines here so they're publicly visible.