### PR TITLE
(MAINT) Update blog prep and header date to Monday

### DIFF
--- a/.github/workflows/blog_prep.yml
+++ b/.github/workflows/blog_prep.yml
@@ -2,7 +2,7 @@ name: Blog Prep
 
 on:
   schedule:
-    - cron: '0 12 * * 4' 
+    - cron: '0 6 * * mon' 
   workflow_dispatch:
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
      - name: Get next blog date
        id: dt
        run: |
-         echo "::set-output name=date::$(date -d 'Fri' --iso-8601)"
+         echo "::set-output name=date::$(date -d 'Mon' --iso-8601)"
 
      - name: Commit changes
        run: |

--- a/bin/blog_tools/bootstrap_blog.rb
+++ b/bin/blog_tools/bootstrap_blog.rb
@@ -6,7 +6,7 @@ require 'erb'
 require_relative 'lib/modules_released'
 require_relative 'lib/community_prs'
 
-blog_post_date = date_of_next_friday
+blog_post_date = date_of_next_monday
 blog_post_filename = "#{blog_post_date}-status-update.md"
 
 workflow = ERB.new(File.read('blog_template/status-update-template.md.erb'), nil, '-').result(binding)

--- a/bin/blog_tools/lib/common.rb
+++ b/bin/blog_tools/lib/common.rb
@@ -10,15 +10,15 @@ MANAGED_TOOLS_URI = URI.parse('https://puppetlabs.github.io/iac/tools.json')
 def last_blog_post_utc_time
   return @last_blog_post_utc_time if defined?(@last_blog_post_utc_time)
 
-  dates = Dir['../../_posts/*status-update.md'].map{|f| f.match(/(?<DATE>\d+-\d+-\d+)-status-update\.md/)['DATE'] } - [ date_of_next_friday ]
+  dates = Dir['../../_posts/*status-update.md'].map{|f| f.match(/(?<DATE>\d+-\d+-\d+)-status-update\.md/)['DATE'] } - [ date_of_next_monday ]
 
   last_blog_post_date = Date.parse(dates.max)
   puts "Last blog date: #{last_blog_post_date.iso8601}"
   @last_blog_post_utc_time = last_blog_post_date.strftime('%s').to_i
 end
 
-def date_of_next_friday
-  date  = Date.parse('Friday')
+def date_of_next_monday
+  date  = Date.parse('Monday')
   delta = date >= Date.today ? 0 : 7
   (date + delta).iso8601
 end


### PR DESCRIPTION
- Updates the blog prep workflow to run on Monday 06:00 UTC (before Community Day starts in Romania)
- Changes the blog date headline and commit messages to "next Monday" date.