### PR TITLE
(GH-305) Remove gem cache steps from deploy and test workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache gems
-        uses: actions/cache@v1
-        with:
-          path: vendor/gems
-          key: ${{ runner.os }}-build-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+      # - name: Cache gems
+      #   uses: actions/cache@v1
+      #   with:
+      #     path: vendor/gems
+      #     key: ${{ runner.os }}-build-${{ hashFiles('**/Gemfile.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
 
       - name: Build & Deploy to GitHub Pages
         uses: DavidS/jekyll-deploy@1.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache gems
-        uses: actions/cache@v1
-        with:
-          path: vendor/gems
-          key: ${{ runner.os }}-build-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+      # - name: Cache gems
+      #   uses: actions/cache@v1
+      #   with:
+      #     path: vendor/gems
+      #     key: ${{ runner.os }}-build-${{ hashFiles('**/Gemfile.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
 
       - name: Test
         uses: DavidS/jekyll-deploy@1.1.1


### PR DESCRIPTION
There were build issues being caused by a stale gem cache.

This commit comments out the gem cache steps in the `test` and
`deploy` workflows.

This should be renabled after a successful workflow run to
rengerate and persist the cache as it significantly cuts down on
the build time.