### PR TITLE
(MAINT) Add a new json endpoint for modules

### DIFF
--- a/_plugins/jsonify_repo_list.rb
+++ b/_plugins/jsonify_repo_list.rb
@@ -5,6 +5,10 @@ module IAC
         [document.data['github'], document.data]
       end].to_json
     end
+
+    def jsonify_repo_list_as_array(input)
+      input.map(&:data).to_json
+    end
   end
 end
 

--- a/modules_list.json.liquid
+++ b/modules_list.json.liquid
@@ -1,0 +1,5 @@
+---
+layout: none
+permalink: /modules-list.json
+---
+{{ site.modules | jsonify_repo_list_as_array }}


### PR DESCRIPTION
## Context

Prior to this PR it was only possible to return an object literal from the modules.json endpoint.

## What has changed

This PR adds a new endpoint and associated plugin called modules-list.json. It returns an array of objects which makes it easier to consume in certain situations.